### PR TITLE
use bytestrings in `etree.fromstring()`

### DIFF
--- a/aiodav/client.py
+++ b/aiodav/client.py
@@ -163,9 +163,6 @@ class Client(object):
         headers_ext: Optional[Dict[str, str]] = None
     ) -> aiohttp.ClientResponse:
         try:
-            if self.session.auth:
-                await self.session.get(url=self._hostname)  # (Re)Authenticates against the proxy
-
             response = await self.session.request(
                 method = Client.DEFAULT_REQUESTS[action],
                 url = self._get_url(path),

--- a/aiodav/client.py
+++ b/aiodav/client.py
@@ -163,6 +163,9 @@ class Client(object):
         headers_ext: Optional[Dict[str, str]] = None
     ) -> aiohttp.ClientResponse:
         try:
+            if self.session.auth:
+                await self.session.get(url=self._hostname)  # (Re)Authenticates against the proxy
+
             response = await self.session.request(
                 method = Client.DEFAULT_REQUESTS[action],
                 url = self._get_url(path),

--- a/aiodav/urn.py
+++ b/aiodav/urn.py
@@ -58,6 +58,6 @@ class Urn(object):
         return result if len(result) < 1 or result[-1] != Urn.separate else result[:-1]
 
     @staticmethod
-    def compare_path(path_a: str, href: str) -> str:
+    def compare_path(path_a: str, href: str) -> bool:
         unqouted_path = Urn.separate + unquote(urlsplit(href).path)
         return Urn.normalize_path(path_a) == Urn.normalize_path(unqouted_path)


### PR DESCRIPTION
`tree = etree.fromstring(content)` would raise a ValueError if content is a unicode string withh encoding declaration
using byte input here fixes this.